### PR TITLE
Fix crypto constants

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs           = require('fs'),
-    constants    = require('crypto').constants,
+    constants    = require('crypto'),
     request      = require('request'),
     util         = require('util'),
     EventEmitter = require('events').EventEmitter,

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs           = require('fs'),
-    constants    = require('crypto'),
+    constants    = require('crypto').constants || require('constants'),
     request      = require('request'),
     util         = require('util'),
     EventEmitter = require('events').EventEmitter,


### PR DESCRIPTION
The upstream changed to accommodate Zendesk deprecating old TLS versions (https://support.zendesk.com/hc/en-us/articles/360000710347-Removal-of-support-for-TLS-protocol-versions-1-0-and-1-1).

Here's the offending change: https://github.com/blakmatrix/node-zendesk/pull/223

This breaks on Node 4 (which we're running). We just need to change this patch such that 